### PR TITLE
Update Redis extension to use release/6.3.0 branch

### DIFF
--- a/src/extensions/redis/Dockerfile
+++ b/src/extensions/redis/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y git && apt-get clean
 RUN if [ $(php -r "echo PHP_VERSION_ID;") -ge 80500 ]; then \
     git clone --branch master --depth 1 https://github.com/igbinary/igbinary.git /usr/src/php/ext/igbinary && \
     docker-php-ext-install igbinary && \
-    git clone --branch develop --depth 1 https://github.com/phpredis/phpredis.git /usr/src/php/ext/redis && \
+    git clone --branch release/6.3.0 --depth 1 https://github.com/phpredis/phpredis.git /usr/src/php/ext/redis && \
     docker-php-ext-configure redis --enable-redis-igbinary && \
     docker-php-ext-install redis; \
   else \


### PR DESCRIPTION
This pull request updates the Redis extension installation process in the `src/extensions/redis/Dockerfile` to use a stable release branch instead of the development branch. This change improves the stability and predictability of the Docker image build.

Symfony also does not support the changes on the current develop branch.

Dependency management:

* Changed the `phpredis` extension installation from cloning the `develop` branch to the `release/6.3.0` branch, ensuring a more stable and predictable build.