### PR TITLE
Mon, Jun 08, 2026 - Xdebug 3.5.3

### DIFF
--- a/src/extensions/xdebug/Dockerfile
+++ b/src/extensions/xdebug/Dockerfile
@@ -5,7 +5,7 @@ FROM ${REPO}:${PHP_VERSION} AS ext
 #VERSION
 # https://pecl.php.net/package/xdebug
 # https://xdebug.org/docs/compat
-ARG XDEBUG_VERSION=3.5.1
+ARG XDEBUG_VERSION=3.5.3
 
 RUN apt-get update && apt-get install -y git \
   && apt-get clean


### PR DESCRIPTION
= Fixed bugs:

- Fixed issue #2404: Xdebug outputs a message to stderr when path mapping is enabled, and a directory is present
- Fixed issue #2405: Handle minimum path in .xdebug directory discovery
- Fixed issue #2411: Native Path Mapping is not applied to the initial fileuri in the init packet
- Fixed issue #2421: Crash with wrong option letter in DBGP and socket commands
- Fixed issue #2422: No limit on DBGP read buffer
- Fixed issue #2423: Don't follow symlinks with file creation
- Fixed issue #2424: Control-socket buffer crashes
- Fixed issue #2426: xdebug_get_tracefile_name incorrectly throws notice
- Fixed issue #2427: Crash when file_link_format setting is wrong
- Fixed issue #2429: Crash when trace_output_name setting is wrong
- Fixed issue #2430: Variable fetching may crash with `::` if there is no active stack
- Fixed issue #2431: Crash when trying to retrieve Windows-style URL with not enough characters
- Fixed issue #2433: Refactor finding variable names in trace files with assignments