### PR TITLE
update: PHP 8.5.8

### DIFF
--- a/src/base/build/8.5/Dockerfile
+++ b/src/base/build/8.5/Dockerfile
@@ -1,3 +1,3 @@
 # https://hub.docker.com/_/php/tags?name=8.5
 # https://php.watch/versions/8.5/releases
-FROM php:8.5.7
+FROM php:8.5.8

--- a/src/base/fpm/8.5/Dockerfile
+++ b/src/base/fpm/8.5/Dockerfile
@@ -1,3 +1,3 @@
 # https://hub.docker.com/_/php/tags?name=8.5
 # https://php.watch/versions/8.5/releases
-FROM php:8.5.7-fpm
+FROM php:8.5.8-fpm


### PR DESCRIPTION
Core:
Fixed bug [GH-22280](https://github.com/php/php-src/issues/22280) (Incorrect compile error for goto to label preceding try/finally block).
Fixed bug [GH-22112](https://github.com/php/php-src/issues/22112) (Assertion when error handler throws during NaN to bool/string coercion).

BCMath:
Fixed issues with oversized allocations and signed overflow in bcround() and BcMath\Number::round().

Date:
Fix incorrect recurrence check of DatePeriod::createFromISO8601String().

Exif:
Read correct value for single and double tags.

GD:
Fixed bug [GH-22121](https://github.com/php/php-src/issues/22121) (Double free in gdImageSetStyle() after overflow-triggered early return).

Intl:
Fix incorrect argument positions for invalid start/end arguments in transliterator_transliterate().
Fixed IntlTimeZone::getDisplayName() to synchronize object error state for invalid display types.

Lexbor:
Merge patch c3a6847.

Opcache:
Fixed bug [GH-22265](https://github.com/php/php-src/issues/22265) (Another tailcall vm_interrupt bug).
Fixed bug [GH-20469](https://github.com/php/php-src/issues/20469) (Unsafe inheritance cache replay with reentrant autoloading).
Fixed bug [GH-21972](https://github.com/php/php-src/issues/21972) (Corrupted variable type when a typed by-value return contains a reference wrapper).

OpenSSL:
Fixed bug [GH-22187](https://github.com/php/php-src/issues/22187) (Memory corruption (zend_mm_heap corrupted) in openssl_encrypt with AES-WRAP-PAD). (CVE-2026-14355)

Phar:
Fixed a bypass of the magic ".phar" directory protection in Phar::addEmptyDir() for paths starting with "/.phar", while allowing non-magic directory names that merely share the ".phar" prefix.

Reflection:
Preserve class-name case in ReflectionClass::getProperty() error messages and autoloading.

SOAP:
Fixed bug [GH-22218](https://github.com/php/php-src/issues/22218) (SoapServer::handle() crash on $_SERVER not being an array).
Fixed bug [GH-22285](https://github.com/php/php-src/issues/22285) (Soap server requires the raw input to be passed to $server->handle).

Sqlite:
Fix error checks for column retrieval.

URI:
Add LEXBOR_STATIC to CFLAGS_URI on Windows so ext/uri does not see LXB_API as __declspec(dllimport) when linked statically into PHP.
Clean error logs before each Uri\WhatWg\Url wither call so that errors from previous wither calls are not returned the next time a UrlValidationError is thrown.

Zip:
Fixed error-related memory leaks.

Zlib:
Fixed memory leak if deflate initialization fails and there is a dict.
Fixed memory leak in inflate_add().