### PR TITLE
update: PHP 8.5.9

### DIFF
--- a/src/base/build/8.2/Dockerfile
+++ b/src/base/build/8.2/Dockerfile
@@ -1,3 +1,3 @@
 # https://hub.docker.com/_/php/tags?name=8.2
 # https://php.watch/versions/8.2/releases
-FROM php:8.2.32-bookworm
+FROM php:8.2.33-bookworm

--- a/src/base/build/8.3/Dockerfile
+++ b/src/base/build/8.3/Dockerfile
@@ -1,3 +1,3 @@
 # https://hub.docker.com/_/php/tags?name=8.3
 # https://php.watch/versions/8.3/releases
-FROM php:8.3.32-bookworm
+FROM php:8.3.33-bookworm

--- a/src/base/build/8.4/Dockerfile
+++ b/src/base/build/8.4/Dockerfile
@@ -1,3 +1,3 @@
 # https://hub.docker.com/_/php/tags?name=8.4
 # https://php.watch/versions/8.4/releases
-FROM php:8.4.23-bookworm
+FROM php:8.4.24-bookworm

--- a/src/base/build/8.5/Dockerfile
+++ b/src/base/build/8.5/Dockerfile
@@ -1,3 +1,3 @@
 # https://hub.docker.com/_/php/tags?name=8.5
 # https://php.watch/versions/8.5/releases
-FROM php:8.5.8
+FROM php:8.5.9

--- a/src/base/fpm/8.2/Dockerfile
+++ b/src/base/fpm/8.2/Dockerfile
@@ -1,3 +1,3 @@
 # https://hub.docker.com/_/php/tags?name=8.2
 # https://php.watch/versions/8.2/releases
-FROM php:8.2.32-fpm-bookworm
+FROM php:8.2.33-fpm-bookworm

--- a/src/base/fpm/8.3/Dockerfile
+++ b/src/base/fpm/8.3/Dockerfile
@@ -1,3 +1,3 @@
 # https://hub.docker.com/_/php/tags?name=8.3
 # https://php.watch/versions/8.3/releases
-FROM php:8.3.32-fpm-bookworm
+FROM php:8.3.33-fpm-bookworm

--- a/src/base/fpm/8.4/Dockerfile
+++ b/src/base/fpm/8.4/Dockerfile
@@ -1,3 +1,3 @@
 # https://hub.docker.com/_/php/tags?name=8.4
 # https://php.watch/versions/8.4/releases
-FROM php:8.4.23-fpm-bookworm
+FROM php:8.4.24-fpm-bookworm

--- a/src/base/fpm/8.5/Dockerfile
+++ b/src/base/fpm/8.5/Dockerfile
@@ -1,3 +1,3 @@
 # https://hub.docker.com/_/php/tags?name=8.5
 # https://php.watch/versions/8.5/releases
-FROM php:8.5.8-fpm
+FROM php:8.5.9-fpm


### PR DESCRIPTION
Core
Fixed bug [GH-22290](https://github.com/php/php-src/issues/22290) (AST pretty printing does not correctly handle strings containing NUL).
Fixed bug [GH-22206](https://github.com/php/php-src/issues/22206) (missing return in global register detection).
Lock unmodified readonly properties for modification after clone-with.

BCMath
Fixed [GHSA-x692-q9x7-8c3f](https://github.com/php/php-src/security/advisories/GHSA-x692-q9x7-8c3f) (Out-of-bounds write in bccomp()). ([CVE-2026-17544](https://nvd.nist.gov/vuln/detail/CVE-2026-17544))

Calendar
Fixed bug [GH-22602](https://github.com/php/php-src/issues/22602) (gregoriantojd() and juliantojd() integer overflow with INT_MAX year).

Date
Update timelib to 2022.17.
Fixed bug [GH-19803](https://github.com/php/php-src/issues/19803) (Parsing a string with a single white space does create an error).
Fixed Unix timestamps in February of the year 0 are misparsed with @-notation.
Fixed bug [GH-11310](https://github.com/php/php-src/issues/11310) (__debugInfo does nothing on userland classes extending Date classes).

DBA
Fixed OOB read on malformed length field in dba flatfile handler.

DOM
Fixed bug [GH-22570](https://github.com/php/php-src/issues/22570) (Stack overflow when serializing a deeply nested Dom\XMLDocument).
Fixed getElementsByClassName() item() returning the wrong element on random access.

Exif
Fixed bug [GH-11020](https://github.com/php/php-src/issues/11020) (exif_read_data() emits a spurious "Illegal IFD size" warning when an IFD is not followed by a next-IFD offset).

GD
Upgrade libgd. ([CVE-2026-9672](https://nvd.nist.gov/vuln/detail/CVE-2026-9672))

Hash
Fixed bug [GH-18173](https://github.com/php/php-src/issues/18173) (ext/hash relies on implementation-defined malloc alignment).

ODBC
Fixed bug [GH-22668](https://github.com/php/php-src/issues/22668) (Heap buffer over-read when a column value exceeds the driver-reported display size).

Opcache
Fixed bug [GH-22158](https://github.com/php/php-src/issues/22158) (Tracing JIT dispatches the observer begin handler through the wrong run_time_cache slot on megamorphic calls).
Fixed bug [GH-22443](https://github.com/php/php-src/issues/22443) (Tracing JIT SIGSEGV on megamorphic dynamic calls from an undereferenced run_time_cache map_ptr offset).
Fixed bug [GH-21770](https://github.com/php/php-src/issues/21770) (Infinite recursion in property hook getter in opcache preloaded trait).

OpenSSL
Fixed timeout for supplemental read at end of a blocking stream in SSL stream wrapper.

Intl
Fixed Locale::lookup() and locale_lookup() to return NULL instead of the fallback locale when a language tag cannot be canonicalized.
Fixed memory leaks when calling Collator::__construct() or Spoofchecker::__construct() twice.
Fixed memory leak when calling IntlListFormatter::__construct() twice.
Fixed IntlChar methods leaving stale global error state after successful calls.

PDO_ODBC
Fixed bug [GH-20726](https://github.com/php/php-src/issues/20726) (Crash with ODBC connection pooling when the DSN carries no credentials).
Fixed bug [GH-22667](https://github.com/php/php-src/issues/22667) (Heap buffer over-read when a column value exceeds the driver-reported display size).
Fixed bug [GH-22666](https://github.com/php/php-src/issues/22666) (Heap buffer overflow when an output parameter value is longer than the declared maxlen).
Fixed bug [GH-22665](https://github.com/php/php-src/issues/22665) (Out-of-bounds write when the ODBC driver reports a diagnostic message length beyond the error buffer).

PGSQL
Fixed [GHSA-7qpv-r5mr-78m4](https://github.com/php/php-src/security/advisories/GHSA-7qpv-r5mr-78m4) (SQL injection via E'...' backslash breakout). ([CVE-2026-17543](https://nvd.nist.gov/vuln/detail/CVE-2026-17543))

Phar
Fixed inconsistent handling of the magic ".phar" directory. Paths such as "/.phar" remain protected, while non-magic paths that merely start with ".phar" are handled consistently across file and directory creation, copying, ArrayAccess, stream lookup, directory iteration and extraction.
Fixed [GHSA-vc5h-9ppw-p5f3](https://github.com/php/php-src/security/advisories/GHSA-vc5h-9ppw-p5f3) (Crash via recursive symlinks). ([CVE-2026-7260](https://nvd.nist.gov/vuln/detail/CVE-2026-7260))

PHPDBG
Fixed bug [GH-17387](https://github.com/php/php-src/issues/17387) (Trivial crash in phpdbg lexer).
Fixed fleaked lowercased lookup keys in phpdbg_resolve_opline_break.
Fixed off-by-one in phpdbg_safe_class_lookup() causing class lookups to always fail during phpdbg's signal-safe interruption path.

Reflection
Fixed bug [GH-22324](https://github.com/php/php-src/issues/22324) (Ignore leading namespace separator in ReflectionParameter::__construct()).
Fixed bug [GH-22441](https://github.com/php/php-src/issues/22441) (ReflectionClass::hasProperty() and getProperty() ignore dynamic properties shadowing a private parent property).
Fixed bug [GH-22658](https://github.com/php/php-src/issues/22658) (ReflectionConstant::__toString() with a string value with null bytes truncates output).
Fixed bug [GH-22683](https://github.com/php/php-src/issues/22683) (Reflection(Class)Constant::__toString() should not warn on NAN conversions).
Fixed bug [GH-22681](https://github.com/php/php-src/issues/22681) (Reflection*::__toString() truncates on null bytes).

Session
Fixed bug [GH-21314](https://github.com/php/php-src/issues/21314) (Different session garbage collector behaviour between PHP 8.3 and PHP 8.5).

SPL
Fix class_parents for classes with leading slash in non-autoload mode.
Ignore leading back-slash in class_parents(), class_implements(), and class_uses().
Fixed bug [GH-16217](https://github.com/php/php-src/issues/16217) (SplFileObject::fputcsv() on an uninitialized object segfaults).

Standard
Fixed bug [GH-22395](https://github.com/php/php-src/issues/22395) (base_convert() outputs at most 64 characters).
Fixed bug [GH-22678](https://github.com/php/php-src/issues/22678) (Use-after-free in array_multisort() when the comparator mutates the array being sorted).

URI
Fixed behavior of Uri\WhatWg\Url wither methods in regard to empty opaque hosts.
Fixed bug [GH-22628](https://github.com/php/php-src/issues/22628) (Percent-encoding of caret in WHATWG URL paths is not performed).
Fixed bug [GH-22629](https://github.com/php/php-src/issues/22629) (WHATWG Validation error incorrect with empty host and non-empty userinfo).

Zip
Fixed bug [GH-22649](https://github.com/php/php-src/issues/22649) (ZipArchive::setCommentName() and setCommentIndex() could crash after overwriting an entry and resetting its inherited unchanged comment).
Fixed bug [GH-21705](https://github.com/php/php-src/issues/21705) (ZipArchive::getFromIndex() ignores ZipArchive::FL_UNCHANGED for deleted entries).